### PR TITLE
Add support for Visual Studio Code with a dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM swift:5.10-noble
+
+RUN apt-get update && \
+    apt-get install -y libadwaita-1.0 libadwaita-1-dev

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
-FROM swift:5.10-noble
+FROM swift:noble
 
-RUN apt-get update && \
+RUN touch /var/mail/ubuntu && \
+    chown ubuntu /var/mail/ubuntu && \
+	userdel -r ubuntu && \
+    apt-get update && \
     apt-get install -y libadwaita-1.0 libadwaita-1-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+    "name": "Swift",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "false",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "false"
+        },
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "os-provided",
+            "ppa": "false"
+		},
+		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {}
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.library": "/usr/lib/liblldb.so"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "sswg.swift-lang"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.flatpak
 /.flatpak-builder
 /build-dir
 /run

--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ For designing an app icon, [App Icon Preview](https://flathub.org/apps/org.gnome
 > You do not have to install any dependencies of Adwaita for Swift, including Swift, on your system.
 > The Adwaita template runs in a [Flatpak](https://flatpak.org/).
 > The GNOME Builder will automatically download dependencies from [Flathub](https://flathub.org).
+> You can also use [Visual Studio Code](https://code.visualstudio.com/) with a Docker [dev container](https://code.visualstudio.com/docs/devcontainers/containers) hosting the Swift toolchain and Adwaita libraries.
 
 ## Usage
 
 1. Open this project in the GNOME Builder. It will start downloading the dependencies.
-2. Build and run the application using the "run" icon in the toolbar.
+    - GNOME Builder will start downloading dependencies when opened.
+    - For Visual Studio Code, enable the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and reopen the project window with the dev container. It may take a couple minutes to build.
+2. Build and run the application.
+    - For GNOME Builder, use the "run" icon in the toolbar.
+    - For Visual Studio Code, select the "run and debug" tab in the leftmost sidebar, and then tap the run icon next to "Debug AdwaitaTemplate".
 3. Change the app's name and other information about the application in the following files (and file names):
     - `README.md`
     - `Package.swift`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For designing an app icon, [App Icon Preview](https://flathub.org/apps/org.gnome
 
 1. Open this project in the GNOME Builder. It will start downloading the dependencies.
     - GNOME Builder will start downloading dependencies when opened.
-    - For Visual Studio Code, enable the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and reopen the project window with the dev container. It may take a couple minutes to build.
+    - For Visual Studio Code, enable the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), the [Swift extension](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang) and the [CodeLLDB extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) and reopen the project window with the dev container. It may take a couple minutes to build.
 2. Build and run the application.
     - For GNOME Builder, use the "run" icon in the toolbar.
     - For Visual Studio Code, select the "run and debug" tab in the leftmost sidebar, and then tap the run icon next to "Debug AdwaitaTemplate".


### PR DESCRIPTION
This PR adds support for developing apps using Visual Studio Code with a [Docker dev container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). The image is built from `.devcontainer/Dockerfile`, which builds from Ubuntu 24.04 and adds libadwaita. This makes it possible to build, run, and debug (with breakpoints) apps from Visual Studio Code. It does not change the steps for GNOME Builder.

README instructions have also been updated to include notes for running with VSCode. To test the PR, clone the template and follow the instructions.